### PR TITLE
eye-tracker error fixed

### DIFF
--- a/eye_tracker.py
+++ b/eye_tracker.py
@@ -180,7 +180,7 @@ while(True):
         eyes = cv2.bitwise_and(img, img, mask=mask)
         mask = (eyes == [0, 0, 0]).all(axis=2)
         eyes[mask] = [255, 255, 255]
-        mid = (shape[42][0] + shape[39][0]) // 2
+        mid = int((shape[42][0] + shape[39][0]) // 2)
         eyes_gray = cv2.cvtColor(eyes, cv2.COLOR_BGR2GRAY)
         threshold = cv2.getTrackbarPos('threshold', 'image')
         _, thresh = cv2.threshold(eyes_gray, threshold, 255, cv2.THRESH_BINARY)


### PR DESCRIPTION
When I try to run eye-tracker.py with python 3 I got the following error message:
``` 
File "eye_tracker.py", line 189, in <module>
    eyeball_pos_left = contouring(thresh[:, 0:mid], mid, img, end_points_left)
TypeError: slice indices must be integers or None or have an __index__ method
```

Therefore I've converted the type of mid to integer. Now it works smoothly! 
Thanks for the tutorial and for the code!